### PR TITLE
chore: updated nuxt version to stable 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,9 +22,9 @@
   "scripts": {
     "dev": "nuxt build --config-file test/fixture/configs/default.js",
     "lint": "eslint lib test",
-    "test": "yarn run lint && jest",
+    "test": "yarn run lint && jest --detectOpenHandles",
     "release": "standard-version && git push --follow-tags && npm publish",
-    "commitlint": "commitlint -e $GIT_PARAMS",
+    "commitlint": "commitlint -e",
     "coverage": "codecov"
   },
   "eslintIgnore": [


### PR DESCRIPTION
removed $GIT_PARAMS as not recognised (-e defaults to commit message)
added missing --detectOpenHandles to jest to stop async processes.