### PR TITLE
fix: avoid purging class used in v-bind:class={}

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Before diving into the individual attributes, here are the default settings of t
     {
       extractor: class {
         static extract(content) {
-          return content.match(/[A-z0-9-:\\/]+/g)
+          return content.match(/[A-Za-z0-9-_/:]*[A-Za-z0-9-_/]+/g)
         }
       },
       extensions: ['html', 'vue', 'js']

--- a/lib/module.js
+++ b/lib/module.js
@@ -32,7 +32,7 @@ export default function nuxtPurgeCss(moduleOptions) {
       {
         extractor: class {
           static extract(content) {
-            return content.match(/[A-z0-9-:\\/]+/g) || []
+            return content.match(/[A-Za-z0-9-_/:]*[A-Za-z0-9-_/]+/g)
           }
         },
         extensions: ['html', 'vue', 'js']

--- a/test/fixture/components/Test.css
+++ b/test/fixture/components/Test.css
@@ -5,3 +5,7 @@
 .ymca {
     text-align: center;
 }
+
+.bound {
+    text-align: center;
+}

--- a/test/fixture/components/Test.vue
+++ b/test/fixture/components/Test.vue
@@ -1,6 +1,8 @@
 <template>
   <div class="ymca">
-    Test
+    <div :class="{ bound: true }">
+      Test
+    </div>
   </div>
 </template>
 

--- a/test/module.test.js
+++ b/test/module.test.js
@@ -38,6 +38,7 @@ describe('nuxt-purgecss', () => {
       const testCSS = await getTestCSS()
       expect(testCSS).not.toMatch('.abc')
       expect(testCSS).toMatch('.ymca')
+      expect(testCSS).toMatch('.bound')
     })
 
     test('don\'t show webpack error message in dev', async () => {
@@ -63,6 +64,7 @@ describe('nuxt-purgecss', () => {
       const testCSS = await getTestCSS()
       expect(testCSS).toMatch('.abc')
       expect(testCSS).toMatch('.ymca')
+      expect(testCSS).toMatch('.bound')
     })
 
     test('define custom options for css lookup (concatenating)', async () => {
@@ -81,6 +83,7 @@ describe('nuxt-purgecss', () => {
       const testCSS = await getTestCSS()
       expect(testCSS).not.toMatch('.abc')
       expect(testCSS).toMatch('.ymca')
+      expect(testCSS).toMatch('.bound')
     })
 
     test('define custom function options for css lookup (overriding)', async () => {
@@ -119,6 +122,7 @@ describe('nuxt-purgecss', () => {
       const testCSS = await getTestCSS('js')
       expect(testCSS).not.toMatch('.abc')
       expect(testCSS).toMatch('.ymca')
+      expect(testCSS).toMatch('.bound')
     })
 
     test('globally disable module', async () => {
@@ -137,6 +141,7 @@ describe('nuxt-purgecss', () => {
       const testCSS = await getTestCSS('js')
       expect(testCSS).toMatch('.abc')
       expect(testCSS).toMatch('.ymca')
+      expect(testCSS).toMatch('.bound')
     })
 
     test('define custom options for css lookup (concatenating)', async () => {
@@ -155,6 +160,7 @@ describe('nuxt-purgecss', () => {
       const testCSS = await getTestCSS('js')
       expect(testCSS).not.toMatch('.abc')
       expect(testCSS).toMatch('.ymca')
+      expect(testCSS).toMatch('.bound')
     })
 
     test('define custom function options for css lookup (overriding)', async () => {


### PR DESCRIPTION
Current regex of default extractor cannot get class names in syntax of `v-bind:class="{}"` correctly.
```html
'<div :class="{ binded: true }" />'.match(/[A-z0-9-:\\/]+/g)
```
<img width="376" alt="スクリーンショット 2019-08-10 0 36 13" src="https://user-images.githubusercontent.com/20733354/62790843-e8b6c200-bb06-11e9-8d5e-f4729e97d6c5.png">
So, the class `binded` will be purged.