### PR TITLE
Do not purge Vue Transition classes by default

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -26,7 +26,9 @@ export default function nuxtPurgeCss(moduleOptions) {
     ],
     styleExtensions: ['.css'],
     whitelist: ['body', 'html', 'nuxt-progress', '__nuxt', '__layout'],
-    whitelistPatterns: [],
+    whitelistPatterns: [
+      /.*-(enter|enter-active|enter-to|leave|leave-active|leave-to)/
+    ],
     whitelistPatternsChildren: [],
     extractors: [
       {

--- a/test/fixture/assets/a.css
+++ b/test/fixture/assets/a.css
@@ -17,3 +17,55 @@ h1 {
 .pattern-a {
     color: red
 }
+
+.v-enter {
+    color: pink
+}
+
+/* Default Vue Transitions */
+
+.v-enter-active {
+    color: violet
+}
+
+.v-enter-to {
+    color: yellow
+}
+
+.v-leave {
+    color: aqua
+}
+
+.v-leave-active {
+    color: magenta
+}
+
+.v-leave-to {
+    color: brown
+}
+
+/* Named Vue Transitions */
+
+.named-transition-enter {
+    color: pink
+}
+
+.named-transition-enter-active {
+    color: violet
+}
+
+.named-transition-enter-to {
+    color: yellow
+}
+
+.named-transition-leave {
+    color: aqua
+}
+
+.named-transition-leave-active {
+    color: magenta
+}
+
+.named-transition-leave-to {
+    color: brown
+}

--- a/test/module.test.js
+++ b/test/module.test.js
@@ -100,6 +100,32 @@ describe('nuxt-purgecss', () => {
       expect(testCSS).not.toMatch('.abc')
       expect(testCSS).not.toMatch('.ymca')
     })
+
+    describe('vue transitions', () => {
+      test('does not purge vue default transitions', async () => {
+        nuxt = await setupNuxt(require('./fixture/configs/webpack/default'))
+
+        const globalCSS = await getGlobalCSS()
+        expect(globalCSS).toMatch('.v-enter')
+        expect(globalCSS).toMatch('.v-enter-active')
+        expect(globalCSS).toMatch('.v-enter-to')
+        expect(globalCSS).toMatch('.v-leave')
+        expect(globalCSS).toMatch('.v-leave-active')
+        expect(globalCSS).toMatch('.v-leave-to')
+      })
+
+      test('does not purge vue named transitions', async () => {
+        nuxt = await setupNuxt(require('./fixture/configs/webpack/default'))
+
+        const globalCSS = await getGlobalCSS()
+        expect(globalCSS).toMatch('.named-transition-enter')
+        expect(globalCSS).toMatch('.named-transition-enter-active')
+        expect(globalCSS).toMatch('.named-transition-enter-to')
+        expect(globalCSS).toMatch('.named-transition-leave')
+        expect(globalCSS).toMatch('.named-transition-leave-active')
+        expect(globalCSS).toMatch('.named-transition-leave-to')
+      })
+    })
   })
   describe('postcss', () => {
     test('purge css by default', async () => {


### PR DESCRIPTION
Vue transition classes are generated dynamically so they're not included in `.vue` files thus purge css ends up purging them.

This PR whitelists Vue Transition classes so that they're not purged from the final css. 

Full list of classes [Vue Transition Classes](https://vuejs.org/v2/guide/transitions.html#Transition-Classes)
