### PR TITLE
chore: upgrade to purgecss 2.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,10 +70,8 @@ Before diving into the individual attributes, here are the default settings of t
   whitelist: ['body', 'html', 'nuxt-progress'],
   extractors: [
     {
-      extractor: class {
-        static extract(content) {
-          return content.match(/[A-z0-9-:\\/]+/g)
-        }
+      extractor(content) {
+        return content.match(/[A-z0-9-:\\/]+/g)
       },
       extensions: ['html', 'vue', 'js']
     }
@@ -198,18 +196,14 @@ export default {
   purgeCSS: {
     extractors: () => [
       {
-        extractor: class {
-          static extract(content) {
-            return content.match(/[A-z0-9-:\\/]+/g)
-          }
+        extractor: (content) {
+          return content.match(/[A-z0-9-:\\/]+/g)
         },
         extensions: ['html', 'vue', 'js']
       },
       {
-        extractor: class {
-          static extract(content) {
-            return content.match(/[A-z0-9-\\/]+/g)
-          }
+        extractor(content) {
+          return content.match(/[A-z0-9-\\/]+/g)
         },
         extensions: ['vue'] // This will not work, because the above extractor is applied to 'vue' already.
       }

--- a/README.md
+++ b/README.md
@@ -11,6 +11,19 @@
 
 [📖 **Release Notes**](./CHANGELOG.md)
 
+## Release Note for purgecss 2
+The extractor is now a function that takes the content as an argument.
+```js
+class Extractor {
+    static extract(content) {}
+}
+```
+changes to
+```js
+function extractor(content) {}
+```
+
+
 ## Features
 
 * Remove unneeded CSS with ease

--- a/lib/module.js
+++ b/lib/module.js
@@ -32,10 +32,8 @@ export default function nuxtPurgeCss(moduleOptions) {
     whitelistPatternsChildren: [],
     extractors: [
       {
-        extractor: class {
-          static extract(content) {
-            return content.match(/[A-z0-9-:\\/]+/g) || []
-          }
+        extractor(content) {
+          return content.match(/[A-z0-9-:\\/]+/g) || []
         },
         extensions: ['html', 'vue', 'js']
       }
@@ -93,6 +91,15 @@ export default function nuxtPurgeCss(moduleOptions) {
   if (Array.isArray(this.options.build.postcss)) {
     logger.error(`build.postcss array option detected. Purgecss will only work in postcss mode with an option object`)
     return
+  }
+
+  if (config.extractors) {
+    config.extractors.forEach((e) => {
+      if (e.extractor && e.extractor.extract) {
+        logger.warn(`extractors need to be defined as function now, transformed class definition to function`)
+        e.extractor = e.extractor.extract
+      }
+    })
   }
 
   const purgeCssPluginsObject = {

--- a/package.json
+++ b/package.json
@@ -54,11 +54,11 @@
     "forceExit": true
   },
   "dependencies": {
-    "@fullhuman/postcss-purgecss": "^1.1.0",
+    "@fullhuman/postcss-purgecss": "^2.0.5",
     "consola": "^1.4.5",
     "glob-all": "^3.1.0",
-    "purgecss": "^1.1.0",
-    "purgecss-webpack-plugin": "^1.4.0"
+    "purgecss": "^2.0.5",
+    "purgecss-webpack-plugin": "^2.0.5"
   },
   "devDependencies": {
     "@commitlint/cli": "^7.5.2",


### PR DESCRIPTION
solves #73 , also checks if old efinition is used and transforms it to the new function one. therefore it is backwards compatible and a non-breaking change.