### PR TITLE
fix(scoped-css): whitelist data-v-* attributes

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -27,7 +27,8 @@ export default function nuxtPurgeCss(moduleOptions) {
     styleExtensions: ['.css'],
     whitelist: ['body', 'html', 'nuxt-progress', '__nuxt', '__layout'],
     whitelistPatterns: [
-      /.*-(enter|enter-active|enter-to|leave|leave-active|leave-to)/
+      /.*-(enter|enter-active|enter-to|leave|leave-active|leave-to)/,
+      /data-v-.*/ // this is needed to prevent removing used scoped css classes
     ],
     whitelistPatternsChildren: [],
     extractors: [


### PR DESCRIPTION
purgecss 2.x removes unused classes when attributes do not match. this is the case when scoped css is used, therefore whitelisting of data-v-* is required.

this is only needed for "webpack" mode, as with the purgecss mode the classes are not scoped yet.

https://github.com/FullHuman/purgecss/issues/277#issuecomment-581475910

Beware, depends on https://github.com/FullHuman/purgecss/pull/279 which is not merged.