### PR TITLE
feat: use official regex and support tailwind ui

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Before diving into the individual attributes, here are the default settings of t
   extractors: [
     {
       extractor(content) {
-        return content.match(/[A-z0-9-:\\/]+/g)
+        return content.match(/[\w-.:/]+(?<!:)/g)
       },
       extensions: ['html', 'vue', 'js']
     }

--- a/lib/module.js
+++ b/lib/module.js
@@ -33,7 +33,7 @@ export default function nuxtPurgeCss(moduleOptions) {
     extractors: [
       {
         extractor(content) {
-          return content.match(/[A-z0-9-:\\/]+/g) || []
+          return content.match(/[\w-.:/]+(?<!:)/g) || []
         },
         extensions: ['html', 'vue', 'js']
       }


### PR DESCRIPTION
This PR changes the regex to the one recommended in the [Tailwind CSS documentation](https://tailwindcss.com/docs/controlling-file-size/#understanding-the-regex).

I also accounted for Tailwind UI, which also has dots in their class names, so I added that to the regex.

```diff
- /[\w-:/]+(?<!:)/g
+ /[\w-.:/]+(?<!:)/g
```