### PR TITLE
fix: update Nuxt 4 peer dependency and @nuxt/kit constraints

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,9 +38,12 @@
     "release": "yarn test && release-it",
     "test": "yarn vitest run"
   },
+  "peerDependencies": {
+    "nuxt": "^3.0.0 || ^4.0.0"
+  },
   "dependencies": {
     "@fullhuman/postcss-purgecss": "^5.0.0",
-    "@nuxt/kit": "^3.2.0",
+    "@nuxt/kit": "^3.2.0 || ^4.0.0",
     "consola": "^2.15.3",
     "glob-all": "^3.3.1",
     "purgecss": "^5.0.0"


### PR DESCRIPTION
## Summary
Updates the package.json to fully support Nuxt 4 alongside Nuxt 3 by loosening the `@nuxt/kit` dependency constraint.

## Problem
Closes #203

Even after #199 updated the module compatibility property, package managers (and Nuxt 4 itself) could still log warnings or duplication errors because `@nuxt/kit` was strictly pinned to `^3.2.0`, and Nuxt wasn't defined in `peerDependencies`. 

## Solution
- Updated `@nuxt/kit` to allow both `^3.2.0 || ^4.0.0`.
- Added `nuxt: ^3.0.0 || ^4.0.0` to `peerDependencies` as recommended in the [Nuxt 4 Module Upgrade Guide](https://nuxt.com/docs/guide/going-further/modules#nuxt-4-compatibility).

## Testing
- Package metadata updated.
- Resolves perfectly without duplication when paired with Nuxt 4.

---
*This PR was created with AI assistance.*